### PR TITLE
Rhiaro datepatch

### DIFF
--- a/exactitude/date.py
+++ b/exactitude/date.py
@@ -78,27 +78,27 @@ class DateType(ExactitudeType):
         return self._clean_text(text)
 
     def fuzzy_date_parser(self, text):
-        """Thin wrapper around ``parsedatetime`` module.
+        """Thin wrapper around ``parsedatetime`` and ``dateutil`` modules.
         Since there's no upstream suppport for multiple locales, this wrapper
         exists.
         :param str text: Text to parse.
         :returns: A parsed date/time object. Raises exception on failure.
         :rtype: datetime
         """
-        locales = parsedatetime._locales[:]
-
-        # Loop through all the locales and try to parse successfully our string
-        for locale in locales:
-            const = parsedatetime.Constants(locale)
-            const.re_option += re.UNICODE
-            parser = parsedatetime.Calendar(const)
-            parsed, ok = parser.parse(text)
-            if ok:
-                return datetime(*parsed[:6])
-
-        # If that didn't work, try dateutil
         try:
             parsed = dateparser.parse(text)
             return parsed
+
         except ValueError, TypeError:
-            return None
+
+            locales = parsedatetime._locales[:]
+
+            # Loop through all the locales and try to parse successfully our
+            # string
+            for locale in locales:
+                const = parsedatetime.Constants(locale)
+                const.re_option += re.UNICODE
+                parser = parsedatetime.Calendar(const)
+                parsed, ok = parser.parse(text)
+                if ok:
+                    return datetime(*parsed[:6])

--- a/exactitude/date.py
+++ b/exactitude/date.py
@@ -3,6 +3,7 @@ import pytz
 import parsedatetime
 from normality import stringify
 from datetime import datetime, date
+from dateutil import parser as dateparser
 
 from exactitude.common import ExactitudeType
 
@@ -94,3 +95,10 @@ class DateType(ExactitudeType):
             parsed, ok = parser.parse(text)
             if ok:
                 return datetime(*parsed[:6])
+
+        # If that didn't work, try dateutil
+        try:
+            parsed = dateparser.parse(text)
+            return parsed
+        except ValueError, TypeError:
+            return None

--- a/exactitude/date.py
+++ b/exactitude/date.py
@@ -89,7 +89,7 @@ class DateType(ExactitudeType):
             parsed = dateparser.parse(text, dayfirst=True)
             return parsed
 
-        except ValueError, TypeError:
+        except (ValueError, TypeError) as e:
 
             locales = parsedatetime._locales[:]
 

--- a/exactitude/date.py
+++ b/exactitude/date.py
@@ -86,7 +86,7 @@ class DateType(ExactitudeType):
         :rtype: datetime
         """
         try:
-            parsed = dateparser.parse(text)
+            parsed = dateparser.parse(text, dayfirst=True)
             return parsed
 
         except ValueError, TypeError:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='exactitude',
-    version='2.1.2',
+    version='2.1.3',
     description="A library with real-world data parsers.",
     long_description="",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'urlnormalizer >= 1.0.3',
         'countrynames >= 1.2',
         'parsedatetime >= 2.1',
+        'python-dateutil >= 2.6.1',
         'phonenumbers >= 8.8.4'
     ],
     tests_require=['nose'],

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -60,6 +60,10 @@ class DatesTest(unittest.TestCase):
         self.assertEquals(dates.clean('2017-04-04'), '2017-04-04')
         # self.assertEquals(parse_date('2017-4-4'), '2017-04-04')
 
+        # I dunno why the first one fails (gets caught by parsedatetime and parsed as today's date) but the second one passes (gets skipped by parsedatetime and dateutil handles it okay)
+        self.assertEquals(dates.clean('03-AUG-2001'), '2001-08-23')
+        self.assertEquals(dates.clean('09-jun-1993'), '1993-06-09')
+
         # TODO: make this yield an imprecise date somehow?
         self.assertEquals(dates.clean('4/2017', format="%m/%Y"), '2017-04-01')
         self.assertEquals(dates.clean('4/2xx017', format="%m/%Y"), None)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -58,9 +58,8 @@ class DatesTest(unittest.TestCase):
         self.assertEquals(dates.clean(None), None)
         self.assertEquals(dates.clean(''), None)
         self.assertEquals(dates.clean('2017-04-04'), '2017-04-04')
-        # self.assertEquals(parse_date('2017-4-4'), '2017-04-04')
+        self.assertEquals(dates.clean('2017-4-4'), '2017-04-04')
 
-        # I dunno why the first one fails (gets caught by parsedatetime and parsed as today's date) but the second one passes (gets skipped by parsedatetime and dateutil handles it okay)
         self.assertEquals(dates.clean('23-AUG-2001'), '2001-08-23')
         self.assertEquals(dates.clean('09-jun-1993'), '1993-06-09')
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -61,7 +61,7 @@ class DatesTest(unittest.TestCase):
         # self.assertEquals(parse_date('2017-4-4'), '2017-04-04')
 
         # I dunno why the first one fails (gets caught by parsedatetime and parsed as today's date) but the second one passes (gets skipped by parsedatetime and dateutil handles it okay)
-        self.assertEquals(dates.clean('03-AUG-2001'), '2001-08-23')
+        self.assertEquals(dates.clean('23-AUG-2001'), '2001-08-23')
         self.assertEquals(dates.clean('09-jun-1993'), '1993-06-09')
 
         # TODO: make this yield an imprecise date somehow?


### PR DESCRIPTION
Uses `dateutil` because that can parse `%d-%b-%Y` out of the box, and falls back to `parsedatetime` for locales. Fixes #1.